### PR TITLE
feat: add support Laravel 11

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: ['8.1', '8.2']
-        laravel: ['^9.1', '^10.0']
+        php: ['8.2', '8.3']
+        laravel: ['^10.0', '^11.0']
 
     steps:
       - name: Checkout the repo

--- a/composer.json
+++ b/composer.json
@@ -20,11 +20,14 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "laravel/framework": "^9.3 || ^10.0"
+        "php": "^8.2",
+        "illuminate/contracts": "^10.0|^11.0",
+        "illuminate/console": "^10.0|^11.0",
+        "illuminate/database": "^10.0|^11.0",
+        "illuminate/support": "^10.0|^11.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^7.7 || ^8.0",
+        "orchestra/testbench": "^8.0|^9.0",
         "spatie/fork": "^1.1"
     },
     "autoload": {

--- a/tests/Unit/Processors/MutexMigrationProcessorTest.php
+++ b/tests/Unit/Processors/MutexMigrationProcessorTest.php
@@ -21,7 +21,6 @@ class MutexMigrationProcessorTest extends TestCase
 
         $this->components = $this->getMockBuilder(Factory::class)
             ->disableOriginalConstructor()
-            ->addMethods(['info', 'warn'])
             ->getMock();
 
         $this->relay = $this->getMockBuilder(MutexRelay::class)
@@ -31,18 +30,18 @@ class MutexMigrationProcessorTest extends TestCase
 
     public function testStart(): void
     {
-        $this->components->expects($this->exactly(2))->method('info');
+        $this->components->expects($this->exactly(2))->method('__call');
 
         $this->relay->expects($this->once())
             ->method('acquireLock')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->getProcessorInstance()->start();
     }
 
     public function testStartThrowsSpecificException(): void
     {
-        $this->components->expects($this->once())->method('info');
+        $this->components->expects($this->once())->method('__call');
 
         $this->relay->expects($this->once())
             ->method('acquireLock')
@@ -55,11 +54,11 @@ class MutexMigrationProcessorTest extends TestCase
 
     public function testTerminate(): void
     {
-        $this->components->expects($this->once())->method('info');
+        $this->components->expects($this->once())->method('__call');
 
         $this->relay->expects($this->once())
             ->method('releaseLock')
-            ->will($this->returnValue(true));
+            ->willReturn(true);
 
         $this->getProcessorInstance()->terminate();
     }


### PR DESCRIPTION
[![JIRA Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Fprobot-netsells.node.ns-client.xyz%2Fbadge%2Flaravel-11)](https://netsells.atlassian.net/browse/laravel-11)

## Overview
- [x] I have performed a self review of my code
- [ ] I have made corresponding changes to the documentation
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added sufficient logging
- [x] New and existing tests pass locally with my changes
- [x] The code modified as part of this PR has been covered with tests

### Summary
Laravel 11 was released yesterday and therefore we need to update our internal packages to support this new version.

Laravel 11 no longer supports PHP 8.1 and therefore I've created a "1.x" and "2.x" branch so that we can continue to maintain both packages for bug fixes. Going forward new features should only be added to v2 of the package.